### PR TITLE
Add context action for converting fields to partial properties

### DIFF
--- a/MvvmPlugin/MvvmPlugin/CHANGELOG.md
+++ b/MvvmPlugin/MvvmPlugin/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 0.4.0
+- Added Convert to observable property context action that can be applied to field decorated with the `ObservableProperty`
+
 ## 0.3.1
 - Fixed bug with NotifyPropertyChangedFor and NotifyCanExecuteFor not working with fields
 

--- a/MvvmPlugin/MvvmPlugin/gradle.properties
+++ b/MvvmPlugin/MvvmPlugin/gradle.properties
@@ -4,7 +4,7 @@
 DotnetPluginId=ReSharperPlugin.MvvmPlugin
 DotnetSolution=ReSharperPlugin.MvvmPlugin.sln
 RiderPluginId=com.jetbrains.rider.plugins.mvvmplugin
-PluginVersion=0.3.1
+PluginVersion=0.4.0
 
 BuildConfiguration=Debug
 

--- a/MvvmPlugin/MvvmPlugin/src/dotnet/ReSharperPlugin.MvvmPlugin/ContextActions/CommunityToolkit/Properties/ConvertToPartialPropertyContextAction.cs
+++ b/MvvmPlugin/MvvmPlugin/src/dotnet/ReSharperPlugin.MvvmPlugin/ContextActions/CommunityToolkit/Properties/ConvertToPartialPropertyContextAction.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Linq;
+using JetBrains.Application.Progress;
+using JetBrains.ProjectModel;
+using JetBrains.ReSharper.Feature.Services.BulbActions;
+using JetBrains.ReSharper.Feature.Services.ContextActions;
+using JetBrains.ReSharper.Feature.Services.CSharp.ContextActions;
+using JetBrains.ReSharper.Psi.CSharp.Tree;
+using JetBrains.ReSharper.Psi.Impl.CodeStyle;
+using JetBrains.ReSharper.Psi.Search;
+using JetBrains.ReSharper.Psi.Tree;
+using JetBrains.Util;
+using ReSharperPlugin.MvvmPlugin.Extensions;
+using ReSharperPlugin.MvvmPlugin.Models;
+
+namespace ReSharperPlugin.MvvmPlugin.ContextActions.CommunityToolkit.Properties;
+
+[ContextAction(Name = "Convert to partial property (CommunityToolkit)",
+    Description =
+        "If the current nuget version of community toolkit supports partial properties this will convert a field decorated with the ObservableProperty attribute a partial property ",
+    GroupType = typeof(CSharpContextActions)
+)]
+public class ConvertToPartialPropertyContextAction(ICSharpContextActionDataProvider provider) : ModernScopedContextActionBase<IFieldDeclaration>
+{
+    public override string Text => "Convert to partial property (CommunityToolkit)";
+    protected override IFieldDeclaration? TryCreateInfoFromDataProvider(IUserDataHolder cache)
+    {
+        if (provider.GetSelectedElement<IFieldDeclaration>() is { } fieldDeclaration)
+        {
+            return fieldDeclaration;
+        }
+
+        return null;
+    }
+
+    protected override bool IsAvailable(IFieldDeclaration availabilityInfo)
+    {
+        if (availabilityInfo.GetContainingTypeDeclaration() is IClassLikeDeclaration cls)
+        {
+            if (!cls.ImplementsObservableObject(observableObject: null) && !cls.CommunityToolkitCanHandlePartialProperties(null))
+            {
+                return false;
+            }
+
+            return availabilityInfo.IsObservableProperty();
+        }
+        
+        return false;
+    }
+
+    protected override IBulbActionCommand? ExecutePsiTransaction(IFieldDeclaration availabilityInfo, ISolution solution,
+        IProgressIndicator progress)
+    {
+        var cls = (IClassLikeDeclaration) availabilityInfo.GetContainingTypeDeclaration()!;
+        
+        // Ensure that the containing class is partial and inherits ObservableObject
+        cls.SetPartial(true);
+
+        
+        var propertyName = availabilityInfo.NameIdentifier.Name.ToPropertyName();
+        
+        // HACK: 
+
+        var referenceExpressions = cls.Descendants<IReferenceExpression>()
+            .ToEnumerable()
+            .Where(x => x.NameIdentifier.Name == availabilityInfo.NameIdentifier.Name)
+            .ToList();
+        
+        var propertyDeclaration = provider.ElementFactory.CreateObservableProperty(propertyName, availabilityInfo.Type, generateObservableAttribute: false);
+
+        foreach (var referenceExpression in referenceExpressions)
+        {
+            referenceExpression.SetName(propertyName);
+        }
+        
+        // If there are attributes on the property add them to the field
+        // The property is filtered away if it is decorated with ObservableProperty
+        // So we don't check for that
+        if (availabilityInfo.Attributes is {Count: > 0} attributes)
+        {
+            foreach (var attribute in attributes)
+            {
+                propertyDeclaration.AddAttributeAfter(attribute, propertyDeclaration.Attributes.LastOrDefault());
+            }
+        }
+        
+        // If there is an initializer on the field. For instance = "Hello World" 
+        // we apply that to the field
+        if (availabilityInfo.Initializer is IExpressionInitializer initializer)
+        {
+            propertyDeclaration.SetInitial(initializer);
+        }
+
+        
+        cls.ReplaceClassMemberDeclaration(availabilityInfo, propertyDeclaration);
+        return null;
+    }
+    
+    
+}

--- a/MvvmPlugin/MvvmPlugin/src/dotnet/ReSharperPlugin.MvvmPlugin/Extensions/ContextActionUtil.cs
+++ b/MvvmPlugin/MvvmPlugin/src/dotnet/ReSharperPlugin.MvvmPlugin/Extensions/ContextActionUtil.cs
@@ -97,7 +97,7 @@ public static class ContextActionUtil
     /// <param name="propertyName"></param>
     /// <param name="propertyType"></param>
     /// <returns></returns>
-    public static IPropertyDeclaration CreateObservableProperty(this CSharpElementFactory factory, string? propertyName = null, IType? propertyType = null)
+    public static IPropertyDeclaration CreateObservableProperty(this CSharpElementFactory factory, string? propertyName = null, IType? propertyType = null, bool generateObservableAttribute = true)
     {
         IPropertyDeclaration propertyDeclaration;
         if (propertyType is null)
@@ -118,7 +118,13 @@ public static class ContextActionUtil
         
         propertyDeclaration.SetPartial(true);
 
-        propertyDeclaration.DecorateWithObservablePropertyAttribute(factory);
+        // This is here for the scenario where we want to copy an existing range of attributes
+        // for instance from a field to a property
+        if (generateObservableAttribute)
+        {
+            propertyDeclaration.DecorateWithObservablePropertyAttribute(factory);    
+        }
+        
               
         return propertyDeclaration;  
     }
@@ -266,5 +272,22 @@ public static class ContextActionUtil
 
         return true;
 
+    }
+
+    public static bool ImplementsObservableObject(this IClassLikeDeclaration declaration,
+        IDeclaredType? observableObject)
+    {
+        observableObject ??= TypeConstants.ObservableObject.GetDeclaredTypeOrNull(declaration);
+        if (observableObject is null)
+        {
+            return false;
+        }
+
+        if (declaration.DeclaredElement?.IsDescendantOf(observableObject.GetTypeElement()) == true)
+        {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/MvvmPlugin/MvvmPlugin/src/dotnet/ReSharperPlugin.MvvmPlugin/Extensions/Extensions.cs
+++ b/MvvmPlugin/MvvmPlugin/src/dotnet/ReSharperPlugin.MvvmPlugin/Extensions/Extensions.cs
@@ -6,6 +6,7 @@ using JetBrains.ReSharper.Feature.Services.LiveTemplates.Templates;
 using JetBrains.ReSharper.Psi;
 using JetBrains.ReSharper.Psi.CSharp.Tree;
 using Microsoft.Build.Evaluation;
+using ReSharperPlugin.MvvmPlugin.Models;
 
 namespace ReSharperPlugin.MvvmPlugin.Extensions;
 
@@ -68,6 +69,20 @@ public static class Extensions
         return string.Concat(char.ToUpper(fieldName[0]), fieldName.Substring(1));
     }
 
+    public static bool IsObservableProperty(this IClassMemberDeclaration declaration)
+    {
+        if (!declaration.Attributes.Any())
+            return false;
+        
+        if (declaration.DeclaredElement is IAttributesSet attributesSet)
+        {
+            return attributesSet.HasAttributeInstance(TypeConstants.ObservableProperty.GetClrName(),
+                false);    
+        }
+
+        return true; 
+    }
+    
     public static bool DoesNotHaveAttribute(this IAttributesOwnerDeclaration item, IDeclaredType attribute)
     {
         // If the field declaration has no Attributes we return true

--- a/MvvmPlugin/MvvmPlugin/src/dotnet/ReSharperPlugin.MvvmPlugin/Models/PluginConstants.cs
+++ b/MvvmPlugin/MvvmPlugin/src/dotnet/ReSharperPlugin.MvvmPlugin/Models/PluginConstants.cs
@@ -18,6 +18,7 @@ public static class PluginConstants
 
 public static class TypeConstants
 {
+    public static readonly ClrTypeNameWrapper ObservableObject = "CommunityToolkit.Mvvm.ComponentModel.ObservableObject";
     public static readonly ClrTypeNameWrapper ObservableProperty = "CommunityToolkit.Mvvm.ComponentModel.ObservablePropertyAttribute";
     public static readonly ClrTypeNameWrapper AsyncRelayCommand = "CommunityToolkit.Mvvm.Input.IAsyncRelayCommand";
     public static readonly ClrTypeNameWrapper RelayCommand = "CommunityToolkit.Mvvm.Input.IRelayCommand";

--- a/MvvmPlugin/MvvmPlugin/src/dotnet/ReSharperPlugin.MvvmPlugin/Models/PluginUtil.cs
+++ b/MvvmPlugin/MvvmPlugin/src/dotnet/ReSharperPlugin.MvvmPlugin/Models/PluginUtil.cs
@@ -25,7 +25,7 @@ public static class PluginUtil
     public static IDeclaredType GetObservableObject(JetBrains.ReSharper.Psi.Tree.ITreeNode treeNode)
     {
         return TypeFactory.CreateTypeByCLRName(
-            "CommunityToolkit.Mvvm.ComponentModel.ObservableObject",
+            TypeConstants.ObservableObject.GetClrName(),
             treeNode.GetPsiModule());
     }
 


### PR DESCRIPTION
Introduced a new context action to convert fields with the `ObservableProperty` attribute into partial properties. Incremented the plugin version to 0.4.0.